### PR TITLE
Fixed regex for getting node_role

### DIFF
--- a/platform_services/manifests/init.pp
+++ b/platform_services/manifests/init.pp
@@ -20,7 +20,7 @@ class platform_services (
   },
   $networks_netmask = 24,
 ) {
-  $node_role = regsubst($::hostname, '^(\w+)-.*$', '\1')
+  $node_role = regsubst($::hostname, '^(.*)-\d+$', '\1')
   $node_nr = regsubst($::hostname, '^.*-(\d+)$', '\1') ? {
     /^\d+$/ => "$0",
     default => '1',


### PR DESCRIPTION
Could you merge this asap? Not sure how it was unrecognized for so long time.

Hostname meteoapi-zookeeper-1 had Role Name: "meteoapi" before instead of meteoapi-zookeeper...
